### PR TITLE
Bugfixes for logging in and clearing UI

### DIFF
--- a/frontend/bankfunction.cpp
+++ b/frontend/bankfunction.cpp
@@ -240,7 +240,7 @@ void BankFunction::processCustomer(QNetworkReply* reply)
 
 
     networkAccessManager->deleteLater();
-    reply->deleteLater();    
+    reply->deleteLater();
 }
 
 void BankFunction::requestTransactions()
@@ -429,13 +429,13 @@ void BankFunction::numAccountSlot(QNetworkReply* reply)
     // Korttiin liitettyjen tilien lukumäärä selvillä ja osataan päättää mihin näkymään siirrytään..
 
     if (numberOfAccounts == 1) // If user has only one account associated with their card, it means they have only debit account and we can skip chooseAccount window
-    {
-        emit changeWidget(2);
+    {        
         accountType = 0;
         getAccountInfo();
+        emit loginResult(5);
     }
     else
     {
-        emit changeWidget(1);
+        emit loginResult(1);
     }
 }

--- a/frontend/bankfunction.h
+++ b/frontend/bankfunction.h
@@ -84,15 +84,12 @@ private:
     QVector<TransactionData*> transactions;
     QString url;
     QNetworkReply* reply;
-    QNetworkReply* accountReply;
-    QNetworkAccessManager* accountManager;
     QByteArray responseData;
     QByteArray loginToken;
 
     void getNumberOfAccounts();
 
 signals:
-    //void changeWidget(int);
     void loginResult(int);
     void transactionsResult(int);
     void withdrawalResult(int result, double remainingBalance = 0.0);

--- a/frontend/mainwindow.cpp
+++ b/frontend/mainwindow.cpp
@@ -41,15 +41,11 @@ MainWindow::MainWindow(QWidget *parent)
     connect(&userMenu, SIGNAL(updateTransactions(int)), bankFunction, SLOT(requestTransactions()));
     connect(bankFunction, SIGNAL(transactionsResult(int)), &accountTransaction, SLOT(updateTransactions()));
 
-    connect(bankFunction, SIGNAL(transactionsResult(int)), &balance, SLOT(updateTransactions()));
-    
-    
+    connect(bankFunction, SIGNAL(transactionsResult(int)), &balance, SLOT(updateTransactions()));    
 
     connect(&chooseAccount, SIGNAL(chooseAccountType(int)), bankFunction, SLOT(setAccountType(int)));
 
     connect(bankFunction, SIGNAL(setCustomerName(QString)), &userMenu, SLOT(setCustomerName(QString)));
-
-
 
     ui->stackedWidget->insertWidget(1, &chooseAccount); // Lisätään tehdyt widgetit, eli yksittäiset pankkiautomaatin näkymät, ja annetaan niille indeksit
     ui->stackedWidget->insertWidget(2, &userMenu);
@@ -58,8 +54,8 @@ MainWindow::MainWindow(QWidget *parent)
     ui->stackedWidget->insertWidget(5, &balance);
     ui->stackedWidget->insertWidget(6, &accountTransaction);
     ui->stackedWidget->insertWidget(7, &deposit);
-    QPixmap bkgnd("img/background.png"); // These 5 lines sets background image to the window
-    //QPixmap bkgnd("../img/background.png"); // These 5 lines sets background image to the window
+
+    QPixmap bkgnd("../img/background.png"); // These 5 lines sets background image to the window
     bkgnd = bkgnd.scaled(this->size(), Qt::IgnoreAspectRatio);
     QPalette palette;
     palette.setBrush(QPalette::Window, bkgnd);

--- a/frontend/mainwindow.cpp
+++ b/frontend/mainwindow.cpp
@@ -58,8 +58,8 @@ MainWindow::MainWindow(QWidget *parent)
     ui->stackedWidget->insertWidget(5, &balance);
     ui->stackedWidget->insertWidget(6, &accountTransaction);
     ui->stackedWidget->insertWidget(7, &deposit);
-
-    QPixmap bkgnd("../img/background.png"); // These 5 lines sets background image to the window
+    QPixmap bkgnd("img/background.png"); // These 5 lines sets background image to the window
+    //QPixmap bkgnd("../img/background.png"); // These 5 lines sets background image to the window
     bkgnd = bkgnd.scaled(this->size(), Qt::IgnoreAspectRatio);
     QPalette palette;
     palette.setBrush(QPalette::Window, bkgnd);
@@ -116,6 +116,8 @@ void MainWindow::loginResult(int result)
         case 1: //Login was successful
             ui->idCardLine->clear();
             ui->passwordLine->clear();
+            ui->infoLabel->setVisible(0);
+            ui->infoLabel->setText("");
             moveToIndex(1);
             break;
         case 2: //No response from server
@@ -129,6 +131,13 @@ void MainWindow::loginResult(int result)
         case 4:
             ui->infoLabel->setVisible(1);
             ui->infoLabel->setText("Liian monta väärää yritystä. Kortti on lukittu.");
+            break;
+        case 5://Login was successful, only debit account exists.
+            ui->idCardLine->clear();
+            ui->passwordLine->clear();
+            ui->infoLabel->setVisible(0);
+            ui->infoLabel->setText("");
+            moveToIndex(2);
             break;
     }
 }


### PR DESCRIPTION
When login is successful, login id and pin are now always cleared. Fix selection of account at login if there are multiple accounts attached to a card